### PR TITLE
Fix pitch accent rendering when the pitch of the particle is differen…

### DIFF
--- a/lib/resources/src/models/words/mod.rs
+++ b/lib/resources/src/models/words/mod.rs
@@ -141,6 +141,11 @@ impl Word {
 
         let res = accent_iter
             .map(|(pos, (part, is_high))| {
+                if part.len() == 0 {
+                    // Don't render under/overline for empty character -- handles the case where the 
+                    // pitch changes from the end of the word to the particle
+                    return vec![];
+                }
                 let borders = vec![if *is_high {
                     Border::Top
                 } else {


### PR DESCRIPTION
…t from the last mora

Previously, possible changes in accent at the end of the word were not considered while rendering. This made it impossible to tell that, for example, ことば is 尾高 while わたし is 平板.

Examples
ことば, which is 尾高, pre-change:
<img width="63" alt="pre" src="https://user-images.githubusercontent.com/90348154/142277182-28f3adaa-d7cd-474e-97cf-1134ca3bcebf.PNG">
Post-change:
<img width="60" alt="post" src="https://user-images.githubusercontent.com/90348154/142277268-c1d1855f-6a30-4bdc-bda7-797a5e030224.PNG">

葉, which is 平板, pre-change: 
<img width="65" alt="pre 1-mora heiban" src="https://user-images.githubusercontent.com/90348154/142277399-e191f332-a8b3-49e7-9338-845e473936cc.PNG">
Post-change:
<img width="60" alt="post 1-mora heiban" src="https://user-images.githubusercontent.com/90348154/142277423-7189320f-1299-496b-9a6f-3553cfb5ae68.PNG">

刃, which is 尾高, pre-change:
<img width="65" alt="pre 1-mora" src="https://user-images.githubusercontent.com/90348154/142277531-ab8fd4e8-514f-4a9c-bfc9-462263d07ce7.PNG">
Post-change:
<img width="64" alt="post 1-mora" src="https://user-images.githubusercontent.com/90348154/142277553-fbe78446-46b0-40b9-a6c5-95066017be74.PNG">

帰る （頭高）、私（平板）、あなた（中高）before and after the change (they remain unchanged): 
<img width="66" alt="pre+post atama" src="https://user-images.githubusercontent.com/90348154/142277765-bfe3a735-6a2a-4747-a52b-6e0467e24243.PNG">
<img width="60" alt="pre+post heiban" src="https://user-images.githubusercontent.com/90348154/142277772-5c923e2e-510e-4408-aa0e-c86ca24e9ff5.PNG">
<img width="63" alt="pre+post naka" src="https://user-images.githubusercontent.com/90348154/142277784-a8a17a5d-1fbb-4996-8a67-8016cbff3f6a.PNG">


