### PR TITLE
Solves #8 -- Make text copy-pastable and Yomichan-able

### DIFF
--- a/html/assets/css/page/multiPage/kana.css
+++ b/html/assets/css/page/multiPage/kana.css
@@ -1,5 +1,4 @@
 .inline-kana-preview {
-    display: block;
     line-height: 1.1;
     font-size: xx-large;
     padding-top: 24px;

--- a/html/assets/css/page/multiPage/kanji.css
+++ b/html/assets/css/page/multiPage/kanji.css
@@ -11,7 +11,6 @@
 }
 
 .kanji-preview {
-    display: block;
     line-height: 1.1;
     font-size: xx-large;
 }

--- a/html/assets/css/page/wordPage.css
+++ b/html/assets/css/page/wordPage.css
@@ -95,6 +95,10 @@
     font-size: 15px;
 }
 
+.furigana-preview {
+    font-size: inherit;
+}
+
 .tags .furigana-preview {
     font-size: 10px;
 }

--- a/lib/frontend/templates/subtemplates/render_sentence.rs.html
+++ b/lib/frontend/templates/subtemplates/render_sentence.rs.html
@@ -2,19 +2,24 @@
 @type MyIterator<'a> = Vec<SentencePartRef<'a>>;
 @(iter: MyIterator)
 
-@for furi_part in iter {
-    @if let Some(kanji) = furi_part.kanji {
-    <div class="furigana-kanji-container">
-        <span class="furigana-preview noselect">
-        @furi_part.kana
-        </span>
-        <span class="kanji-preview">
-        @kanji
-        </span>
-    </div>
-    } else {
-    <div class="inline-kana-preview">
-        @furi_part.kana
-    </div>
-    }
-}
+<div class="furigana-kanji-container"><!--
+-->@for furi_part in iter {<!--
+    -->@if furi_part.kana.len() != 0 {<!--
+        --><ruby><!--
+            --><span class="kanji-preview"><!--
+            -->@if let Some(kanji) = furi_part.kanji {<!--
+                    -->@kanji<!--
+                --></span><!--
+                --><rp>（</rp><rt class="furigana-preview noselect"><!--
+                    -->@furi_part.kana<!--
+            -->} else {<!--
+                    -->@furi_part.kana<!--
+                --></span><!--
+                --><rp>（</rp><rt class="furigana-preview noselect"><!--
+                    -->　<!-- note that this is a japanese space -- putting anything else gives wrong height
+            -->}<!--
+            --></rt><rp>）</rp><!--
+        --></ruby><!--
+    -->}<!--
+-->}<!--
+--></div>

--- a/lib/frontend/templates/subtemplates/render_sentence.rs.html
+++ b/lib/frontend/templates/subtemplates/render_sentence.rs.html
@@ -1,0 +1,20 @@
+@use japanese::furigana::SentencePartRef;
+@type MyIterator<'a> = Vec<SentencePartRef<'a>>;
+@(iter: MyIterator)
+
+@for furi_part in iter {
+    @if let Some(kanji) = furi_part.kanji {
+    <div class="furigana-kanji-container">
+        <span class="furigana-preview noselect">
+        @furi_part.kana
+        </span>
+        <span class="kanji-preview">
+        @kanji
+        </span>
+    </div>
+    } else {
+    <div class="inline-kana-preview">
+        @furi_part.kana
+    </div>
+    }
+}

--- a/lib/frontend/templates/subtemplates/render_sentence.rs.html
+++ b/lib/frontend/templates/subtemplates/render_sentence.rs.html
@@ -6,21 +6,22 @@
 <div class="furigana-kanji-container">@*
 *@@for furi_part in iter {@*
     *@@if !furi_part.kana.is_empty() {@*
-        *@<ruby>@*
-            *@<span class="kanji-preview @addl_classes">@*
             *@@if let Some(kanji) = furi_part.kanji {@*
-                    *@@kanji@*
-                *@</span>@*
-                *@<rp>（</rp><rt class="furigana-preview noselect @addl_classes">@*
-                    *@@furi_part.kana@*
+                *@<ruby>@*
+                    *@<span class="kanji-preview @addl_classes">@*
+                        *@@kanji@*
+                    *@</span>@*
+                    *@<rp>（</rp>@*
+                    *@<rt class="furigana-preview noselect @addl_classes">@*
+                        *@@furi_part.kana@*
+                    *@</rt>@*
+                    *@<rp>）</rp>@*
+                *@</ruby>@*
             *@} else {@*
+                *@<span class="inline-kana-preview @addl_classes">@*
                     *@@furi_part.kana@*
                 *@</span>@*
-                *@<rp>（</rp><rt class="furigana-preview noselect @addl_classes">@*
-                    *@　@* note that this is a japanese space -- putting anything else gives wrong height
             *@}@*
-            *@</rt><rp>）</rp>@*
-        *@</ruby>@*
     *@}@*
 *@}@*
 *@</div>

--- a/lib/frontend/templates/subtemplates/render_sentence.rs.html
+++ b/lib/frontend/templates/subtemplates/render_sentence.rs.html
@@ -1,21 +1,21 @@
 @use japanese::furigana::SentencePartRef;
-@type MyIterator<'a> = Vec<SentencePartRef<'a>>;
-@(iter: MyIterator)
+@type MyVec<'a> = Vec<SentencePartRef<'a>>;
+@(iter: MyVec, addl_classes: &str)
 
 <div class="furigana-kanji-container"><!--
 -->@for furi_part in iter {<!--
-    -->@if furi_part.kana.len() != 0 {<!--
+    -->@if !furi_part.kana.is_empty() {<!--
         --><ruby><!--
-            --><span class="kanji-preview"><!--
+            --><span class="kanji-preview @addl_classes"><!--
             -->@if let Some(kanji) = furi_part.kanji {<!--
                     -->@kanji<!--
                 --></span><!--
-                --><rp>（</rp><rt class="furigana-preview noselect"><!--
+                --><rp>（</rp><rt class="furigana-preview noselect @addl_classes"><!--
                     -->@furi_part.kana<!--
             -->} else {<!--
                     -->@furi_part.kana<!--
                 --></span><!--
-                --><rp>（</rp><rt class="furigana-preview noselect"><!--
+                --><rp>（</rp><rt class="furigana-preview noselect @addl_classes"><!--
                     -->　<!-- note that this is a japanese space -- putting anything else gives wrong height
             -->}<!--
             --></rt><rp>）</rp><!--

--- a/lib/frontend/templates/subtemplates/render_sentence.rs.html
+++ b/lib/frontend/templates/subtemplates/render_sentence.rs.html
@@ -1,25 +1,26 @@
 @use japanese::furigana::SentencePartRef;
+@* TODO Figure out how to use Iterator instead of Vec for this template. *@
 @type MyVec<'a> = Vec<SentencePartRef<'a>>;
 @(iter: MyVec, addl_classes: &str)
 
-<div class="furigana-kanji-container"><!--
--->@for furi_part in iter {<!--
-    -->@if !furi_part.kana.is_empty() {<!--
-        --><ruby><!--
-            --><span class="kanji-preview @addl_classes"><!--
-            -->@if let Some(kanji) = furi_part.kanji {<!--
-                    -->@kanji<!--
-                --></span><!--
-                --><rp>（</rp><rt class="furigana-preview noselect @addl_classes"><!--
-                    -->@furi_part.kana<!--
-            -->} else {<!--
-                    -->@furi_part.kana<!--
-                --></span><!--
-                --><rp>（</rp><rt class="furigana-preview noselect @addl_classes"><!--
-                    -->　<!-- note that this is a japanese space -- putting anything else gives wrong height
-            -->}<!--
-            --></rt><rp>）</rp><!--
-        --></ruby><!--
-    -->}<!--
--->}<!--
---></div>
+<div class="furigana-kanji-container">@*
+*@@for furi_part in iter {@*
+    *@@if !furi_part.kana.is_empty() {@*
+        *@<ruby>@*
+            *@<span class="kanji-preview @addl_classes">@*
+            *@@if let Some(kanji) = furi_part.kanji {@*
+                    *@@kanji@*
+                *@</span>@*
+                *@<rp>（</rp><rt class="furigana-preview noselect @addl_classes">@*
+                    *@@furi_part.kana@*
+            *@} else {@*
+                    *@@furi_part.kana@*
+                *@</span>@*
+                *@<rp>（</rp><rt class="furigana-preview noselect @addl_classes">@*
+                    *@　@* note that this is a japanese space -- putting anything else gives wrong height
+            *@}@*
+            *@</rt><rp>）</rp>@*
+        *@</ruby>@*
+    *@}@*
+*@}@*
+*@</div>

--- a/lib/frontend/templates/subtemplates/sentence_search.rs.html
+++ b/lib/frontend/templates/subtemplates/sentence_search.rs.html
@@ -21,7 +21,7 @@
     @for sentence in sentences {
       <div class="list-entry sentence">
         <div class="d-flex flex-row wrap sentence">
-          @:render_sentence_html(sentence.sentence.furigana_pairs())
+          @:render_sentence_html(sentence.sentence.furigana_pairs().collect())
         </div>
 
         <div class="sentence-translation original">

--- a/lib/frontend/templates/subtemplates/sentence_search.rs.html
+++ b/lib/frontend/templates/subtemplates/sentence_search.rs.html
@@ -21,7 +21,7 @@
     @for sentence in sentences {
       <div class="list-entry sentence">
         <div class="d-flex flex-row wrap sentence">
-          @:render_sentence_html(sentence.sentence.furigana_pairs().collect())
+          @:render_sentence_html(sentence.sentence.furigana_pairs().collect(), "small")
         </div>
 
         <div class="sentence-translation original">

--- a/lib/frontend/templates/subtemplates/sentence_search.rs.html
+++ b/lib/frontend/templates/subtemplates/sentence_search.rs.html
@@ -1,6 +1,8 @@
 @use search::sentence::result::Item;
 @use super::search_help;
 @use crate::BaseData;
+@use super::render_sentence_html;
+
 @(data: &BaseData, sentences: Vec<Item>)
 
   <link rel="stylesheet" type="text/css" href="/assets/css/page/multiPage/kanji.css">
@@ -19,23 +21,7 @@
     @for sentence in sentences {
       <div class="list-entry sentence">
         <div class="d-flex flex-row wrap sentence">
-
-          @for spair in sentence.sentence.furigana_pairs() {
-            @if spair.kanji.is_some() {
-              <div class="furigana-kanji-container">
-                <span class="furigana-preview small noselect">
-                  @spair.kana
-                </span>
-                <span class="kanji-preview small">
-                  @spair.kanji.unwrap()
-                </span>
-              </div>
-            } else {
-              <div class="inline-kana-preview small">
-                @spair.kana
-              </div>
-            }
-          }
+          @:render_sentence_html(sentence.sentence.furigana_pairs())
         </div>
 
         <div class="sentence-translation original">

--- a/lib/frontend/templates/subtemplates/word_search.rs.html
+++ b/lib/frontend/templates/subtemplates/word_search.rs.html
@@ -49,7 +49,7 @@
         @for part in sentence_parts {
           @if let Some(ref furigana) = part.furigana {
             <a id="p@part.pos" href="/search/@query.query?i=@part.pos" class="@part.get_add_class() d-flex flex-row sentence-part @selected(part.pos, result.sentence_index)">
-              @:render_sentence_html(furi_from_str(furigana).collect())
+              @:render_sentence_html(furi_from_str(furigana).collect(), "")
             </a>
           } else {
             <a id="p@part.pos" href="/search/@query.query?i=@part.pos" class="@part.get_add_class() inline-kana-preview sentence-part @selected(part.pos, result.sentence_index)">@part.text</a>
@@ -86,7 +86,7 @@
           @if word.get_reading().len() > 3 {
             <div class="d-flex flex-row wrap"> 
               @if let Some(s_pairs) = word.get_furigana() {
-                @:render_sentence_html(s_pairs)
+                @:render_sentence_html(s_pairs, "")
               } else {
                 <div class="inline-kana-preview">
                   @word.get_reading().reading
@@ -102,7 +102,7 @@
               @if word.get_reading().len() <= 3 {
                 <div class="d-flex flex-row"> 
                   @if let Some(s_pairs) = word.get_furigana() {
-                    @:render_sentence_html(s_pairs)
+                    @:render_sentence_html(s_pairs, "")
                   } else {
                     <div class="inline-kana-preview">
                       @word.get_reading().reading
@@ -238,7 +238,7 @@
                             <div class="d-flex flex-row">
                               <div class="tags no-margin example-sentence collapsed"> 
                                 <div class="d-flex flex-row wrap">               
-                                  @:render_sentence_html(furi)
+                                  @:render_sentence_html(furi, "")
                                 </div>
                               </div>
                               <div class="expander">

--- a/lib/frontend/templates/subtemplates/word_search.rs.html
+++ b/lib/frontend/templates/subtemplates/word_search.rs.html
@@ -5,6 +5,7 @@
 @use crate::BaseData;
 @use japanese::furigana::from_str as furi_from_str;
 @use crate::example_sentence::ext_sentence;
+@use super::render_sentence_html;
 
 @(data: &BaseData, query: &Query, result: WordResult)
 
@@ -48,22 +49,7 @@
         @for part in sentence_parts {
           @if let Some(ref furigana) = part.furigana {
             <a id="p@part.pos" href="/search/@query.query?i=@part.pos" class="@part.get_add_class() d-flex flex-row sentence-part @selected(part.pos, result.sentence_index)">
-              @for furi_part in furi_from_str(furigana) {
-                @if let Some(kanji) = furi_part.kanji {
-                  <div class="furigana-kanji-container">
-                    <span class="furigana-preview noselect">
-                      @furi_part.kana
-                    </span>
-                    <span class="kanji-preview">
-                      @kanji
-                    </span>
-                  </div>
-                } else {
-                  <div class="inline-kana-preview">
-                    @furi_part.kana
-                  </div>
-                }
-              }
+              @:render_sentence_html(furi_from_str(furigana).collect())
             </a>
           } else {
             <a id="p@part.pos" href="/search/@query.query?i=@part.pos" class="@part.get_add_class() inline-kana-preview sentence-part @selected(part.pos, result.sentence_index)">@part.text</a>
@@ -100,22 +86,7 @@
           @if word.get_reading().len() > 3 {
             <div class="d-flex flex-row wrap"> 
               @if let Some(s_pairs) = word.get_furigana() {
-                @for spair in s_pairs {
-                  @if spair.kanji.is_some() {
-                     <div class="furigana-kanji-container">
-                        <span class="furigana-preview noselect">
-                           @spair.kana
-                        </span>
-                        <span class="kanji-preview">
-                           @spair.kanji.unwrap()
-                        </span>
-                     </div>
-                  } else {
-                     <div class="inline-kana-preview">
-                        @spair.kana
-                     </div>
-                  }
-                }
+                @:render_sentence_html(s_pairs)
               } else {
                 <div class="inline-kana-preview">
                   @word.get_reading().reading
@@ -131,22 +102,7 @@
               @if word.get_reading().len() <= 3 {
                 <div class="d-flex flex-row"> 
                   @if let Some(s_pairs) = word.get_furigana() {
-                    @for spair in s_pairs {
-                      @if spair.kanji.is_some() {
-                         <div class="furigana-kanji-container">
-                            <span class="furigana-preview noselect">
-                               @spair.kana
-                            </span>
-                            <span class="kanji-preview">
-                               @spair.kanji.unwrap()
-                            </span>
-                         </div>
-                      } else {
-                         <div class="inline-kana-preview">
-                            @spair.kana
-                         </div>
-                      }
-                    }
+                    @:render_sentence_html(s_pairs)
                   } else {
                     <div class="inline-kana-preview">
                       @word.get_reading().reading
@@ -282,22 +238,7 @@
                             <div class="d-flex flex-row">
                               <div class="tags no-margin example-sentence collapsed"> 
                                 <div class="d-flex flex-row wrap">               
-                                  @for spair in furi {
-                                    @if spair.kanji.is_some() {
-                                      <div class="furigana-kanji-container">
-                                        <span class="furigana-preview noselect">
-                                          @spair.kana
-                                        </span>
-                                        <span class="kanji-preview">
-                                          @spair.kanji.unwrap()
-                                        </span>
-                                      </div>
-                                    } else {
-                                      <div class="inline-kana-preview">
-                                        @spair.kana
-                                      </div>
-                                    }
-                                  }
+                                  @:render_sentence_html(furi)
                                 </div>
                               </div>
                               <div class="expander">


### PR DESCRIPTION
See #8. Kanji/furigana display code has been refactored into render_sentence.rs.html. A few changes were made to CSS, so things change location slightly on the page, but everything still looks good. On my machine at least (Windows 10, Chrome), copy and paste now works with no whitespace inserted, and Yomichan works.